### PR TITLE
Control register overview of the SCM was updated.

### DIFF
--- a/src/02_spec/07_modules/scm/dbgregisters.rst
+++ b/src/02_spec/07_modules/scm/dbgregisters.rst
@@ -2,44 +2,6 @@ Programmer Interface: Control Registers
 ---------------------------------------
 
 The System Control Module implements the :ref:`sec:spec:api:base_register_map`.
-The reset values are listed below.
-
-.. tabularcolumns:: |p{\dimexpr 0.20\linewidth-2\tabcolsep}|p{\dimexpr 0.20\linewidth-2\tabcolsep}|p{\dimexpr 0.40\linewidth-2\tabcolsep}|p{\dimexpr 0.20\linewidth-2\tabcolsep}|
-.. flat-table:: SCM base register reset values
-  :widths: 2 2 4 2
-  :header-rows: 1
-
-  * - address
-    - name
-    - description
-    - reset value
-
-  * - 0x0000
-    - ``MOD_ID``
-    - module type identifier
-    - 0x0001
-
-  * - 0x0001
-    - ``MOD_VERSION``
-    - module version
-    - 0x0000
-
-  * - 0x0002
-    - ``MOD_VENDOR``
-    - module vendor
-    - 0x0001
-
-  * - 0x0003
-    - ``MOD_CS``
-    - module control and status
-    - 0x0000
-
-  * - 0x0004
-    - ``MOD_EVENT_DEST``
-    - destination of debug events
-    - impl.-specific
-
-
 Additionally, it implements the following control registers for module-specific functionality.
 
 


### PR DESCRIPTION
The Programmer Interface: Control Registers page of the SCM contained an old overview of its base register set. The order and the names of the registers changed meanwhile, so the old overview was taken out bringing the page more in line with e.g. the already updated MAM. 
There is of course still a link to the correct base register overview.