### PR TITLE
05_components.rst: Fix typo in the description of the DII last signal

### DIFF
--- a/src/02_spec/05_components.rst
+++ b/src/02_spec/05_components.rst
@@ -80,7 +80,7 @@ All debug components must conform to the DII when accessing the Debug Interconne
   * - ``last``
     - master
     - 1
-    - Set to 0b1 by the master to indicate that ``data`` is the last word in a Debug Packet. Set to 0b1 otherwise.
+    - Set to 0b1 by the master to indicate that ``data`` is the last word in a Debug Packet. Set to 0b0 otherwise.
 
   * - ``valid``
     - master


### PR DESCRIPTION
This fixes the typo and changes it from 0b1 --> 0b0.