### PR TITLE
stm/systemif.rst: Fix typo in the description of STM Trace generation

### DIFF
--- a/src/02_spec/07_modules/stm/systemif.rst
+++ b/src/02_spec/07_modules/stm/systemif.rst
@@ -46,7 +46,7 @@ trace events.
 In the hardware implementation the writeback stage must be observed and
 whenever a write to register ``r3`` is observed, the same value is
 stored into the register ``value``. When completion of an ``l.nop``
-operation is observed, the opeand ``K`` (if not equal to 0) and the
+operation is observed, the operand ``K`` (if not equal to 0) and the
 ``value`` are emitted on the trace port for one cycle.
 
 Finally, the following extension is required to support the trace event


### PR DESCRIPTION
This fixes typo in the Software Trace Port: OpenRISC description and changes opeand --> operand.